### PR TITLE
Add initial lookup functionality to the bugjira library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # Bugjira
-Bugjira is an abstraction layer library for interacting with either bugzilla or JIRA through the use of their respective python libraries.
+Bugjira is an abstraction layer library for interacting with either bugzilla or JIRA via their respective python libraries.
+
+## Examples
+
+Bugjira users can perform common operations (lookup, query, modify, etc) on both bugs (bugzilla) and issues (jira) using the Bugjira object.
+
+Configuration is provided with either a dict (see below) or a pathname to a config file containing a json dict (a sample config file is included in `contrib/bugjira.json`):
+
+```python
+config = {
+    "bugzilla": {
+        "URL": "https://bugzilla.yourdomain.com",
+        "api_key": "your_bugzilla_api_key"},
+    "jira": {
+        "URL": "https://jira.yourdomain.com",
+        "token_auth": "your_jira_personal_access_token"}
+ }
+
+bugjira_api = Bugjira(config_dict=config)
+```
+
+(Note that the `config_dict` parameter takes precedence; i.e. if you instantiate the Bugjira class with both a config_path and a config_dict parameter, the resulting instance will use the config_dict's values.)
+
+After initializing a Bugjira instance, you can use its methods to look up either bugs or issues. The object returned by the Bugjira instance is of type `bugjira.Issue` which (TODO) allows access to the underlying attributes of the wrapped bug or jira issue:
+```python
+bz = bugjira_api.get_issue("123456")
+assert bz.key == "123456"
+```
+Instances of `bugjira.Issue` have attributes called `bugzilla` and `jira_issue` that are set by their respective backend broker so that you can easily tell what type of Issue you're dealing with. As a convenience, those attributes are pointers to the wrapped bug or jira issue. So if the Issue class' methods don't give you what you need, you have the actual bug or jira issue whenever you need it:
+```python
+if bz.bugzilla:
+    print(f"Product is: {bz.bugzilla.product})
+# You can also use type checking since the backends return subclasses of Issue
+if isinstance(bz, bugjira.BugzillaIssue):
+    print(f"Product is: {bz.bugzilla.product}")
+assert not isinstance(bz, bugjira.JiraIssue)
+```
+
+Similarly, if the `bugjira.Bugjira` instance's API doesn't give you what you need, you can easily get a handle to the underlying Bugzilla or JIRA backend API object via the `bugzilla` and `jira_api` attributes and then use it as you like:
+```python
+bugzilla_api = bugjira_api.bugzilla
+actual_bz = bugzilla_api.getbug("123456") # using the Bugzilla api object's getbug
+print("Fetched bug #%s:" % actual_bz.id)
+```
+or
+```python
+jira_api = bugjira_api.jira
+issue = jira_api.get_issue("FOO-123") # using the JIRA api object's get_issue
+```

--- a/contrib/bugjira.json
+++ b/contrib/bugjira.json
@@ -1,0 +1,10 @@
+{
+    "bugzilla": {
+        "server": "https://bugzilla.redhat.com",
+        "api_key": "your_api_key_here"
+    },
+    "jira": {
+        "server": "https://issues.redhat.com",
+        "token_auth": "your_personal_auth_token_here"
+    }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ package_dir =
 packages = find:
 python_requires = >=3.7
 install_requires =
+    pydantic
+    python-bugzilla
+    jira
 
 [options.extras_require]
 devbase =
@@ -33,6 +36,7 @@ test =
     flake8
     pytest
     pytest-cov
+    mock
 
 docs =
     sphinx==4.3.1

--- a/src/bugjira/broker.py
+++ b/src/bugjira/broker.py
@@ -1,0 +1,111 @@
+from bugzilla import Bugzilla
+from jira import JIRA
+
+from bugjira.config import Config
+from bugjira.issue import BugzillaIssue, Issue, JiraIssue
+
+
+class Broker:
+    def __init__(self, config=None, backend=None) -> None:
+        """Init method for the Broker class
+
+        :param config: An optional config dict, defaults to None
+        :type config: dict, optional
+        :param backend: An optional API backend instance, defaults to None
+        :type backend: object, optional
+        :raises BrokerInitException: If neither a config nor a backend is
+            provided
+        """
+        if config is None and backend is None:
+            raise BrokerInitException("API backend or config dict required")
+        self.backend = backend
+
+    def get_issue(self, key) -> Issue:
+        # Override in subclasses
+        pass
+
+
+class BugzillaBroker(Broker):
+    """A Broker for interacting with bugzilla"""
+
+    def __init__(self, config=None, backend=None) -> None:
+        """Init method for the BugzillaBroker class
+
+        :param config: A dict containing config information for the bugzilla
+            backend, defaults to None
+        :type config: dict, optional
+        :param backend: A pre-initialized bugzilla api backend object, defaults
+            to None
+        :type backend: bugzilla.Bugzilla, optional
+        """
+        super().__init__(config, backend)
+        if self.backend is None:
+            config = Config.from_config(config_dict=config)
+            url = config.get("bugzilla").get("URL")
+            api_key = config.get("bugzilla").get("api_key")
+            self.backend = Bugzilla(url, api_key=api_key)
+
+    def get_issue(self, key) -> BugzillaIssue:
+        """Return an Issue that wraps a bugzilla bug returned by the backend
+
+        :param key: A bugzilla bug id to lookup in bugzilla
+        :type key: str
+        :raises BrokerLookupException: if an Exception occurs when using the
+            backend's getbug method
+        :return: A BugzillaIssue that wraps a bugzilla bug
+        :rtype: BugzillaIssue
+        """
+        try:
+            bug = self.backend.getbug(key)
+        except Exception as e:
+            raise BrokerLookupException(e)
+        return BugzillaIssue(key=key, bugzilla=bug)
+
+
+class JiraBroker(Broker):
+    """A Broker for interacting with JIRA"""
+
+    def __init__(self, config=None, backend=None) -> None:
+        """Init method for the JiraBroker class
+
+        :param config: A dict containing config information for the Jira
+            backend, defaults to None
+        :type config: dict, optional
+        :param backend: A pre-initialized Jira api backend object, defaults to
+            None
+        :type backend: jira.JIRA, optional
+        """
+        super().__init__(config, backend)
+        if self.backend is None:
+            config = Config.from_config(config_dict=config)
+            url = config.get("jira").get("URL")
+            token_auth = config.get("jira").get("token_auth")
+            self.backend = JIRA(url, token_auth=token_auth)
+
+    def get_issue(self, key) -> JiraIssue:
+        """Return an Issue that wraps a JIRA issue returned by the backend
+
+        :param key: A jira issue key to lookup in jira
+        :type key: str
+        :raises BrokerLookupException: if an Exception occurs when using the
+            backend's issue method
+        :return: A JiraIssue that wraps a JIRA issue
+        :rtype: JiraIssue
+        """
+        try:
+            issue = self.backend.issue(key)
+        except Exception as e:
+            raise BrokerLookupException(e)
+        return JiraIssue(key=key, jira_issue=issue)
+
+
+class BrokerException(Exception):
+    pass
+
+
+class BrokerInitException(BrokerException):
+    pass
+
+
+class BrokerLookupException(BrokerException):
+    pass

--- a/src/bugjira/bugjira.py
+++ b/src/bugjira/bugjira.py
@@ -1,0 +1,75 @@
+from bugjira.broker import BugzillaBroker, JiraBroker
+from bugjira.config import Config
+from bugjira.issue import Issue
+from bugjira.util import is_bugzilla_key, is_jira_key
+
+
+class Bugjira:
+    """API abstraction layer object for a bugzilla backend and a jira
+    backend."""
+
+    def __init__(
+        self, config_path="", config_dict=None, bugzilla=None, jira=None
+    ):
+        """Init method for the Bugjira class. Note that if both config_dict and
+        config_path parameters are provided, the config_dict will take
+        precedence.
+
+        :param config_path: Absolute path to a json config file, defaults to ""
+        :type config_path: str, optional
+        :param config_dict: A dict containing configuration info for Bugzilla
+            and Jira instances
+        :type config_dict: dict, optional
+        :param bugzilla: An already-initialized bugzilla.Bugzilla instance,
+            defaults to None
+        :type bugzilla: bugzilla.Bugzilla, optional
+        :param jira: An already-initialized jira.JIRA instance, defaults to
+            None
+        :type jira: jira.JIRA, optional
+        """
+        self.config = None
+        if config_dict:
+            self.config = Config.from_config(config_dict=config_dict)
+        elif config_path:
+            self.config = Config.from_config(config_path=config_path)
+
+        self._bugzilla_broker = BugzillaBroker(
+            config=self.config, backend=bugzilla
+        )
+        self.bugzilla = self._bugzilla_broker.backend
+
+        self._jira_broker = JiraBroker(config=self.config, backend=jira)
+        self.jira = self._jira_broker.backend
+
+    def get_issue(self, key) -> Issue:
+        """Return an Issue using the correct Broker based on the key input
+
+        :param key: The lookup key
+        :type key: str
+        :return: A bugjira Issue that wraps the bugzilla or jira returned by
+            the broker
+        :rtype: Issue
+        """
+        if not isinstance(key, str):
+            raise ValueError(f"key must be a string: {key}")
+        broker = self._get_broker(key)
+        return broker.get_issue(key)
+
+    def _get_broker(self, key):
+        """Private method to return the correct backend Broker based on the
+        input key.
+
+        :param key: Either a bugzilla bug id or a Jira issue key
+        :type key: str
+        :raises ValueError: If the input key is not a bugzilla id or a jira
+            issue key
+        :return: The correct Broker to handle operations on the Issue
+        :rtype: bugjira.broker.Broker
+        """
+        if is_bugzilla_key(key):
+            return self._bugzilla_broker
+
+        if is_jira_key(key):
+            return self._jira_broker
+
+        raise ValueError("key does not appear to be bugzilla or jira ID")

--- a/src/bugjira/config.py
+++ b/src/bugjira/config.py
@@ -1,0 +1,47 @@
+import json
+
+from pydantic import BaseModel, validator
+
+
+class Config(BaseModel):
+    """A BaseModel to validate config dicts"""
+
+    config_dict: dict
+
+    @validator("config_dict")
+    def validate_minimum_config(cls, v):
+        assert v.get("bugzilla")
+        assert v.get("bugzilla").get("URL")
+        assert v.get("bugzilla").get("api_key")
+        assert v.get("jira")
+        assert v.get("jira").get("URL")
+        assert v.get("jira").get("token_auth")
+        return v
+
+    @staticmethod
+    def from_config(config_path=None, config_dict=None):
+        """Returns a Config instance based on either a json file specified by
+        the config_path parameter or a dict specified by the config_dict
+        parameter. If both a path and a dict are provided, use the dict to
+        generate the config.
+
+        :param config_path: Full path to a valid json config file, defaults to
+            None
+        :type config_path: str, optional
+        :param config_dict: A dict containing configuration settings, defaults
+            to None
+        :type config_dict: dict, optional
+        :raises ValueError: If no parameters are supplied
+        :return: A validated config dict for connecting to the bugzilla and
+            jira backends
+        :rtype: dict
+        """
+        if config_dict is not None:
+            return Config(config_dict=config_dict).config_dict
+        if config_path is not None:
+            with open(config_path) as conf:
+                config_dict = json.loads(conf.read())
+                return Config(config_dict=config_dict).config_dict
+        raise ValueError(
+            "from_config requires config_path or config_dict parameters"
+        )

--- a/src/bugjira/issue.py
+++ b/src/bugjira/issue.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Issue(BaseModel):
+    """BaseModel representing either a bugzilla bug or a jira issue.
+    Future refactoring will allow access to the bug/issue's attributes
+    via instances of this class.
+    """
+
+    key: str
+    bugzilla: Any
+    jira_issue: Any
+
+
+class BugzillaIssue(Issue):
+    pass
+
+
+class JiraIssue(Issue):
+    pass

--- a/src/bugjira/util.py
+++ b/src/bugjira/util.py
@@ -1,0 +1,35 @@
+import re
+
+
+def is_bugzilla_key(key):
+    """returns True if the input key is in the format of a bugzilla bug ID
+
+    :param key: The input key to test
+    :type key: str
+    :raises ValueError: If the key is not of type str
+    :return: True if the input key is in the format of a bugzilla bug ID
+    :rtype: bool
+    """
+    if not isinstance(key, str):
+        raise ValueError(f"Key must be a str: {key}")
+    bz = re.compile("^[0-9]+$")
+    if bz.match(key):
+        return True
+    return False
+
+
+def is_jira_key(key):
+    """returns True if the input key is in the format of a JIRA issue key
+
+    :param key: The input key to test
+    :type key: str
+    :raises ValueError: If the key is not of type str
+    :return: True if the input key is in the format of a JIRA issue key
+    :rtype: bool
+    """
+    if not isinstance(key, str):
+        raise ValueError(f"Key must be a str: {key}")
+    jira = re.compile("[a-zA-Z]+-[0-9]+")
+    if jira.match(key):
+        return True
+    return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+from bugjira.config import Config
+
+
+@pytest.fixture
+def config_defaults():
+    _dir = os.path.dirname(os.path.realpath(__file__))
+    return _dir
+
+
+@pytest.fixture()
+def good_config_file_path(config_defaults):
+    return config_defaults + "/data/config/good_config.json"
+
+
+@pytest.fixture
+def good_config_dict(good_config_file_path):
+    return Config.from_config(config_path=good_config_file_path)

--- a/tests/data/config/good_config.json
+++ b/tests/data/config/good_config.json
@@ -1,0 +1,7 @@
+{"bugzilla": {
+    "URL": "https://bugzilla.yourdomain.com",
+    "api_key": "your_bugzilla_api_key"},
+ "jira": {
+    "URL": "https://jira.yourdomain.com",
+    "token_auth": "your_jira_personal_access_token"}
+ }

--- a/tests/data/config/missing_config.json
+++ b/tests/data/config/missing_config.json
@@ -1,0 +1,7 @@
+{"bugzilla": {
+    "URL": "",
+    "api_key": ""},
+ "jira": {
+    "URL": "",
+    "token_auth": ""}
+ }

--- a/tests/test_stub.py
+++ b/tests/test_stub.py
@@ -1,3 +1,0 @@
-def test_pytest():
-    # no-op test to show that pytest can run in the tox environment
-    pass

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -1,0 +1,106 @@
+from unittest.mock import Mock, create_autospec
+
+import pytest
+from bugzilla import Bugzilla
+from jira import JIRA
+from pydantic.error_wrappers import ValidationError
+
+import bugjira.broker as broker
+from bugjira.broker import (
+    Broker,
+    BrokerInitException,
+    BugzillaBroker,
+    JiraBroker,
+)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup(monkeypatch):
+    monkeypatch.setattr(broker, "Bugzilla", create_autospec(Bugzilla))
+    monkeypatch.setattr(broker, "JIRA", create_autospec(JIRA))
+
+
+def test_broker_init_no_backend():
+    """
+    GIVEN the Broker class' constructor
+    WHEN we call it without supplying a backend parameter
+    THEN the resulting instance's backend attribute should be None
+    """
+    broker = Broker(config={})
+    assert broker.backend is None
+
+
+def test_broker_init_with_backend():
+    """
+    GIVEN the Broker class' constructor
+    WHEN we call it with a backend parameter supplied
+    THEN the resulting instance's backend attribute should be the one we input
+        to the constructor
+    """
+    backend = Mock()
+    broker = Broker(backend=backend)
+    assert broker.backend == backend
+
+
+def test_broker_init_with_no_parameters():
+    """
+    GIVEN the Broker class' constructor
+    WHEN we call it with no parameters
+    THEN a BrokerInitException should be raised
+    """
+    with pytest.raises(BrokerInitException):
+        Broker()
+
+
+def test_broker_init_with_no_config_and_no_backend():
+    """
+    GIVEN the Broker class' constructor
+    WHEN we call it with None for both parameters
+    THEN a BrokerInitException should be raised
+    """
+    with pytest.raises(BrokerInitException):
+        Broker(config=None, backend=None)
+
+
+def test_bugzilla_broker_init_with_valid_config(good_config_dict):
+    """
+    GIVEN the BugzillaBroker class
+    WHEN we instantiate it
+    THEN the instance's backend should have a method called 'getbug'
+    """
+    bzb = BugzillaBroker(config=good_config_dict)
+    # We won't check the type here because backend is a Mock created via
+    # create_autospec, but we'll just make sure the method name is an attribute
+    assert bzb.backend.getbug
+
+
+def test_bugzilla_broker_init_with_invalid_config():
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN it is called with only an invalid (in this case, empty) config dict
+    THEN a ValidationError will be raised
+    """
+    with pytest.raises(ValidationError):
+        BugzillaBroker(config={})
+
+
+def test_jira_broker_init_with_invalid_config():
+    """
+    GIVEN the Jira class' constructor
+    WHEN it is called with only an invalid (in this case, empty) config dict
+    THEN a ValidationError will be raised
+    """
+    with pytest.raises(ValidationError):
+        JiraBroker(config={})
+
+
+def test_jira_broker_init_with_valid_config(good_config_dict):
+    """
+    GIVEN the JiraBroker class
+    WHEN we instantiate it
+    THEN the instance's backend should have a method called 'issue'
+    """
+    jb = JiraBroker(config=good_config_dict)
+    # We won't check the type here because backend is a Mock created via
+    # create_autospec, but we'll just make sure the method name is an attribute
+    assert jb.backend.issue

--- a/tests/unit/test_bugjira.py
+++ b/tests/unit/test_bugjira.py
@@ -1,0 +1,242 @@
+from copy import deepcopy
+from unittest.mock import Mock, create_autospec
+from xmlrpc.client import Fault
+
+import pytest
+from bugzilla import Bugzilla
+from jira import JIRA
+from jira.exceptions import JIRAError
+
+import bugjira.broker as broker
+from bugjira.broker import BrokerLookupException
+from bugjira.bugjira import Bugjira
+from bugjira.issue import BugzillaIssue, JiraIssue
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup(monkeypatch):
+    """Patch out the bugzilla.Bugzilla and jira.JIRA constructors
+    in the broker module so that we don't attempt to connect to an actual
+    backend
+    """
+    monkeypatch.setattr(broker, "Bugzilla", create_autospec(Bugzilla))
+    monkeypatch.setattr(broker, "JIRA", create_autospec(JIRA))
+
+
+@pytest.fixture(scope="function")
+def sandboxed_bugjira(good_config_dict):
+    return Bugjira(config_dict=good_config_dict)
+
+
+def test_init_with_config_dict(good_config_dict):
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with a valid config dict
+    THEN the resulting Bugjira instance's config attribute will be the dict
+        we input to the constructor
+    AND the broker and backend attributes should be present
+    """
+    bugjira = Bugjira(config_dict=good_config_dict)
+    assert bugjira.config == good_config_dict
+    assert bugjira._bugzilla_broker
+    assert bugjira._jira_broker
+    assert bugjira.bugzilla
+    assert bugjira.jira
+
+
+def test_init_with_config_path(good_config_file_path, good_config_dict):
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with a path to a known good config file
+    THEN the resulting instance's config attribute should be equivalent to the
+        contents of the config file
+    AND the broker and backend attributes should be present
+    """
+    bugjira = Bugjira(config_path=good_config_file_path)
+    assert bugjira.config == good_config_dict
+    assert bugjira._bugzilla_broker
+    assert bugjira._jira_broker
+    assert bugjira.bugzilla
+    assert bugjira.jira
+
+
+def test_init_with_both_path_and_dict(good_config_file_path, good_config_dict):
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with a path and a dict
+    THEN the resulting instance's config attribute should be equivalent to the
+        contents of the config dict
+    """
+    # Assumption: the good_config_file_path and good_config_dict should produce
+    # the same dict contents. So if we deepcopy the good_config_dict, edit
+    # the result, and pass the modified dict into the Bugjira constructor,
+    # we can test for equivalence and difference as below.
+    edited_dict = deepcopy(good_config_dict)
+    edited_dict["bugzilla"]["URL"] = "foo"
+    bugjira = Bugjira(
+        config_path=good_config_file_path, config_dict=edited_dict
+    )
+    assert bugjira.config != good_config_dict
+    assert bugjira.config == edited_dict
+
+
+def test_init_with_no_parameters():
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with no parameters
+    THEN a BrokerInitException should be raised
+    """
+    with pytest.raises(broker.BrokerInitException):
+        Bugjira()
+
+
+def test_init_with_only_bz_backend_supplied():
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with only the bugzilla parameter supplied
+    THEN a BrokerInitException should be raised
+    """
+    with pytest.raises(broker.BrokerInitException):
+        Bugjira(bugzilla=Mock())
+
+
+def test_init_with_only_jira_backend_supplied():
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with only the jira parameter supplied
+    THEN a BrokerInitException should be raised
+    """
+    with pytest.raises(broker.BrokerInitException):
+        Bugjira(jira=Mock())
+
+
+def test_init_with_both_backends_and_config(good_config_dict):
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with bugzilla and jira parameters and a valid config
+    THEN no exception is raised
+    AND the instance backends are the same as what we passed to the constructor
+    """
+    bugzilla = Mock()
+    jira = Mock()
+    bugjira = Bugjira(
+        config_dict=good_config_dict, bugzilla=bugzilla, jira=jira
+    )
+    assert bugjira.bugzilla == bugzilla
+    assert bugjira.jira == jira
+
+
+def test_init_with_both_backends_and_no_config():
+    """
+    GIVEN the Bugjira class' constructor
+    WHEN we call it with bugzilla and jira parameters and a no config
+    THEN no exception is raised
+    AND the instance backends are the same as what we passed to the constructor
+    """
+    bugzilla = Mock()
+    jira = Mock()
+    bugjira = Bugjira(bugzilla=bugzilla, jira=jira)
+    assert bugjira.bugzilla == bugzilla
+    assert bugjira.jira == jira
+
+
+def test_get_broker_with_bugzilla_id(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance's _get_broker method
+    WHEN we call it with a key string that represents a bugzilla bug id
+    THEN the instance's _bugzilla_broker attribute should be returned
+    """
+    broker = sandboxed_bugjira._get_broker("123456")
+    assert broker == sandboxed_bugjira._bugzilla_broker
+
+
+def test_get_broker_with_jira_issue_id(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance's _get_broker method
+    WHEN we call it with a key string that represents a jira issue key
+    THEN the instance's _jira_broker attribute should be returned
+    """
+    broker = sandboxed_bugjira._get_broker("FOO-123")
+    assert broker == sandboxed_bugjira._jira_broker
+
+
+def test_get_broker_with_invalid_string_key(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance's _get_broker method
+    WHEN we call it with a key string that is neither a bugzilla or jira key
+    THEN a ValueError should be raised
+    """
+    with pytest.raises(ValueError):
+        sandboxed_bugjira._get_broker("BADKEY123")
+
+
+def test_get_issue_with_non_string_key(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance's get_issue method
+    WHEN we call it with a non-string parameter
+    THEN a ValueError is raised
+    """
+    with pytest.raises(ValueError):
+        sandboxed_bugjira.get_issue(1)
+
+
+def test_get_issue_good_bugzilla(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance
+    WHEN we invoke the get_issue method with a BZ number
+    THEN it should return an instance of Issue with a non-None bugzilla
+        attribute and a key matching the input
+    AND the instance's bugzilla attribute should have had its getbug method
+        invoked once
+    """
+    key = "123456"
+    issue = sandboxed_bugjira.get_issue(key)
+    assert isinstance(issue, BugzillaIssue)
+    assert issue.bugzilla
+    assert not issue.jira_issue
+    assert issue.key == key
+    assert sandboxed_bugjira.bugzilla.getbug.call_count == 1
+
+
+def test_get_issue_bad_bugzilla(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance
+    WHEN we invoke the get_issue method with a BZ number using a bug id that is
+        known not to correspond to any bug on the remote bugzilla service
+    THEN a BrokerLookupException exception should be raised
+    """
+    sandboxed_bugjira.bugzilla.getbug.side_effect = Fault(
+        "Fault 101", "Bug #XXX does not exist."
+    )
+    with pytest.raises(BrokerLookupException):
+        sandboxed_bugjira.get_issue("123")
+
+
+def test_get_issue_good_jira_issue(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance
+    WHEN we invoke the get_issue method with a Jira issue key
+    THEN it should return an instance of Issue with a non-None jira_issue
+        attribute and a key matching the input
+    AND the instance's jira attribute should have had its issue method invoked
+        once
+    """
+    key = "FOO-123"
+    issue = sandboxed_bugjira.get_issue(key)
+    assert isinstance(issue, JiraIssue)
+    assert issue.jira_issue
+    assert not issue.bugzilla
+    assert issue.key == key
+    assert sandboxed_bugjira.jira.issue.call_count == 1
+
+
+def test_get_issue_bad_jira_issue(sandboxed_bugjira):
+    """
+    GIVEN a Bugjira instance
+    WHEN we invoke the get_issue method with a JIRA issue key using a key that
+        is known not to correspond to any issue on the remote bugzilla service
+    THEN a BrokerLookupException exception should be raised
+    """
+    sandboxed_bugjira.jira.issue.side_effect = JIRAError
+    with pytest.raises(BrokerLookupException):
+        sandboxed_bugjira.get_issue("FOO-666")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,84 @@
+from copy import deepcopy
+
+import pytest
+from pydantic.error_wrappers import ValidationError
+
+from bugjira.config import Config
+
+
+def test_config_good_json(config_defaults):
+    """
+    GIVEN a json file containing a valid definition of a Bugjira config dict
+    WHEN we call Config.from_config with its pathname
+    THEN no exception is raised
+    """
+    config = Config.from_config(
+        config_path=(config_defaults + "/data/config/good_config.json")
+    )
+    assert config is not None
+
+
+def test_config_good_dict(good_config_dict):
+    """
+    GIVEN a well-defined dict containing a Bugjira config
+    WHEN we call Config.from_config using the dict as the config_dict
+    THEN no exception is raised
+    AND the dict returned is the dict that was passed in
+    """
+    assert Config.from_config(config_dict=good_config_dict) == good_config_dict
+
+
+def test_config_missing_values(config_defaults):
+    """
+    GIVEN a json file containing an incomplete definition of a Bugjira config
+    WHEN we call Config.from_config with the path to the file
+    THEN a ValidationError is raised
+    """
+    with pytest.raises(ValidationError):
+        Config.from_config(
+            config_path=(config_defaults + "/data/config/missing_config.json")
+        )
+
+
+def test_config_no_file(config_defaults):
+    """
+    GIVEN a filepath pointing to a non-existent file
+    WHEN we call Config.from_config using the filepath as the config_path
+    THEN a FileNotFoundError is raised
+    """
+    with pytest.raises(FileNotFoundError):
+        Config.from_config(
+            config_path=(config_defaults + "/data/config/does_not_exist.json")
+        )
+
+
+def test_config_both_path_and_dict(good_config_file_path, good_config_dict):
+    """
+    GIVEN a path to a valid config file, and a dict that varies slightly from
+        the file's config data
+    WHEN the get_config method is called using these non-None values for both
+        the config_path and config_dict parameters
+    THEN the config dict returned by get_config should match the config dict
+    """
+    # First grab the config_dict from the good config path,
+    # copy it, and change a value in the copy
+    edited_dict = deepcopy(good_config_dict)
+    edited_dict["bugzilla"]["URL"] = "foo"
+    # Now call get_config with both the path and the edited dict
+    result = Config.from_config(
+        config_path=good_config_file_path, config_dict=edited_dict
+    )
+    # show that the returned dict from get_config matches the one we get from
+    # the config_dict
+    assert result == edited_dict
+    assert result != good_config_dict
+
+
+def test_config_no_params():
+    """
+    GIVEN the from_config method
+    WHEN we call it with no parameters
+    THEN a ValueError should be raised
+    """
+    with pytest.raises(ValueError):
+        Config.from_config()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,54 @@
+import pytest
+
+from bugjira.util import is_bugzilla_key, is_jira_key
+
+
+def test_is_key_with_non_str():
+    """
+    GIVEN the is_bugzilla_key and is_jira_key methods
+    WHEN they are called with a non-str input
+    THEN a ValueError is raised
+    """
+    for test in is_bugzilla_key, is_jira_key:
+        with pytest.raises(ValueError):
+            test(1)
+
+
+@pytest.mark.parametrize("key", ["123456", "1"])
+def test_is_bugzilla_key_true(key):
+    """
+    GIVEN the is_bugzilla_key method
+    WHEN it is called with a str that matches the bz id format
+    THEN the method returns True
+    """
+    assert is_bugzilla_key(key) is True
+
+
+@pytest.mark.parametrize("key", ["RHOSOR-123", "1a"])
+def test_is_bugzilla_key_false(key):
+    """
+    GIVEN the is_bugzilla_key method
+    WHEN it is called with a str that doesn't match the bz id format
+    THEN the method returns False
+    """
+    assert is_bugzilla_key(key) is False
+
+
+@pytest.mark.parametrize("key", ["RHOSOR-123", "PCTOOLING-654", "test-123"])
+def test_is_jira_key_true(key):
+    """
+    GIVEN the is_jira_key method
+    WHEN it is called with a str that matches the jira key format
+    THEN the method returns True
+    """
+    assert is_jira_key(key) is True
+
+
+@pytest.mark.parametrize("key", ["23456", "1a", "PCTOOLING123", "123-abc"])
+def test_is_jira_key_false(key):
+    """
+    GIVEN the is_jira_key method
+    WHEN it is called with a str that doesn't match the jira key format
+    THEN the method returns False
+    """
+    assert is_jira_key(key) is False


### PR DESCRIPTION
Adds a new class, Bugjira, that acts as an abstraction layer for the bugzilla.Bugzilla and jira.JIRA classes' functionality.

Allows lookup of bugzilla or jira issues from their respective remote services using a single get_issue(key) method. Which service to query is determined by the pattern of the key parameter, i.e. passing in a bug id will cause a bugzilla query, and passing in a JIRA issue key will query the Jira service.

The returned bug (bz) or issue (jira) is wrapped in a new class: Issue. This class will, in future versions, provide additional abstraction to allow interacting with the respective remote object types.

In both cases, the remote objects that we are abstracting can be accessed directly. Instances of Bugjira have attributes, bugzilla and jira, that are pointers to the bugzilla.Bugzilla and jira.JIRA objects whose lookup methods are what this patch attempts to abstract. Similarly, instances of Issue have attributes, bugzilla and jira_issue, that are set conditionally to point to either a bugzilla object or a jira issue (i.e. what we are actually getting back from the backend api libraries). So if the abstraction provided by the bugjira library is insufficient for your use case, you can switch directly to using the bugzilla or jira libraries at will.