### PR TITLE
Fix contrib config file

### DIFF
--- a/contrib/bugjira.json
+++ b/contrib/bugjira.json
@@ -1,10 +1,10 @@
 {
     "bugzilla": {
-        "server": "https://bugzilla.redhat.com",
+        "URL": "https://bugzilla.redhat.com",
         "api_key": "your_api_key_here"
     },
     "jira": {
-        "server": "https://issues.redhat.com",
+        "URL": "https://issues.redhat.com",
         "token_auth": "your_personal_auth_token_here"
     }
 }


### PR DESCRIPTION
A small change did not get propagated from the test data files to the default config file we provide in contrib/. This patch fixes that.