### PR TITLE
Use pydantic for key validation

### DIFF
--- a/src/bugjira/issue.py
+++ b/src/bugjira/issue.py
@@ -1,6 +1,8 @@
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
+
+from bugjira.util import is_bugzilla_key, is_jira_key
 
 
 class Issue(BaseModel):
@@ -15,8 +17,14 @@ class Issue(BaseModel):
 
 
 class BugzillaIssue(Issue):
-    pass
+    @validator("key")
+    def validate_key(cls, key):
+        assert is_bugzilla_key(key)
+        return key
 
 
 class JiraIssue(Issue):
-    pass
+    @validator("key")
+    def validate_key(cls, key):
+        assert is_jira_key(key)
+        return key

--- a/src/bugjira/util.py
+++ b/src/bugjira/util.py
@@ -29,7 +29,7 @@ def is_jira_key(key):
     """
     if not isinstance(key, str):
         raise ValueError(f"Key must be a str: {key}")
-    jira = re.compile("[a-zA-Z]+-[0-9]+")
+    jira = re.compile("[a-zA-Z]+[-_][0-9]+")
     if jira.match(key):
         return True
     return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,23 @@ def good_config_file_path(config_defaults):
 @pytest.fixture
 def good_config_dict(good_config_file_path):
     return Config.from_config(config_path=good_config_file_path)
+
+
+@pytest.fixture
+def good_bz_keys():
+    return ["123456", "1"]
+
+
+@pytest.fixture
+def bad_bz_keys():
+    return ["RHOSOR-123", "1a"]
+
+
+@pytest.fixture
+def good_jira_keys():
+    return ["RHOSOR-123", "PCTOOLING-654", "test-123", "FOO_123"]
+
+
+@pytest.fixture
+def bad_jira_keys():
+    return ["23456", "1a", "PCTOOLING123", "123-abc"]

--- a/tests/unit/test_issue.py
+++ b/tests/unit/test_issue.py
@@ -1,0 +1,48 @@
+import pytest
+from pydantic.error_wrappers import ValidationError
+
+from bugjira.issue import BugzillaIssue, JiraIssue
+
+
+def test_good_bz_keys(good_bz_keys):
+    """
+    GIVEN a set of well-formatted bz keys
+    WHEN we create a BugzillaIssue with each key
+    THEN no ValidationError is raised and the issue key matches the input key
+    """
+    for key in good_bz_keys:
+        issue = BugzillaIssue(key=key)
+        assert issue.key == key
+
+
+def test_bad_bz_keys(bad_bz_keys):
+    """
+    GIVEN a set of poorly-formatted bz keys
+    WHEN we create a BugzillaIssue with each key
+    THEN a ValidationError is raised
+    """
+    for key in bad_bz_keys:
+        with pytest.raises(ValidationError):
+            BugzillaIssue(key=key)
+
+
+def test_good_jira_keys(good_jira_keys):
+    """
+    GIVEN a set of well-formatted jira keys
+    WHEN we create a JiraIssue with each key
+    THEN no ValidationError is raised and the issue key matches the input key
+    """
+    for key in good_jira_keys:
+        issue = JiraIssue(key=key)
+        assert issue.key == key
+
+
+def test_bad_jira_keys(bad_jira_keys):
+    """
+    GIVEN a set of poorly-formatted jira keys
+    WHEN we create a JiraIssue with each key
+    THEN a ValidationError is raised
+    """
+    for key in bad_jira_keys:
+        with pytest.raises(ValidationError):
+            JiraIssue(key=key)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -14,41 +14,41 @@ def test_is_key_with_non_str():
             test(1)
 
 
-@pytest.mark.parametrize("key", ["123456", "1"])
-def test_is_bugzilla_key_true(key):
+def test_is_bugzilla_key_true(good_bz_keys):
     """
     GIVEN the is_bugzilla_key method
     WHEN it is called with a str that matches the bz id format
     THEN the method returns True
     """
-    assert is_bugzilla_key(key) is True
+    for key in good_bz_keys:
+        assert is_bugzilla_key(key) is True
 
 
-@pytest.mark.parametrize("key", ["RHOSOR-123", "1a"])
-def test_is_bugzilla_key_false(key):
+def test_is_bugzilla_key_false(bad_bz_keys):
     """
     GIVEN the is_bugzilla_key method
     WHEN it is called with a str that doesn't match the bz id format
     THEN the method returns False
     """
-    assert is_bugzilla_key(key) is False
+    for key in bad_bz_keys:
+        assert is_bugzilla_key(key) is False
 
 
-@pytest.mark.parametrize("key", ["RHOSOR-123", "PCTOOLING-654", "test-123"])
-def test_is_jira_key_true(key):
+def test_is_jira_key_true(good_jira_keys):
     """
     GIVEN the is_jira_key method
     WHEN it is called with a str that matches the jira key format
     THEN the method returns True
     """
-    assert is_jira_key(key) is True
+    for key in good_jira_keys:
+        assert is_jira_key(key) is True
 
 
-@pytest.mark.parametrize("key", ["23456", "1a", "PCTOOLING123", "123-abc"])
-def test_is_jira_key_false(key):
+def test_is_jira_key_false(bad_jira_keys):
     """
     GIVEN the is_jira_key method
     WHEN it is called with a str that doesn't match the jira key format
     THEN the method returns False
     """
-    assert is_jira_key(key) is False
+    for key in bad_jira_keys:
+        assert is_jira_key(key) is False


### PR DESCRIPTION
Allows JIRA issue names like FOO-123 or FOO_123 since that is supported by JIRA api.

Uses pydantic validation in the Issue class to validate keys (leveraging existing is_(bugzilla|jira)_key methods).

Moves the lists of good/bad keys for testing into a fixture to avoid duplicate definitions.