### PR TITLE
Do not use assert in Issue validator methods

### DIFF
--- a/src/bugjira/issue.py
+++ b/src/bugjira/issue.py
@@ -19,12 +19,16 @@ class Issue(BaseModel):
 class BugzillaIssue(Issue):
     @validator("key")
     def validate_key(cls, key):
-        assert is_bugzilla_key(key)
+        if not is_bugzilla_key(key):
+            raise ValueError(f"{key} is not a \
+                valid bugzilla key")
         return key
 
 
 class JiraIssue(Issue):
     @validator("key")
     def validate_key(cls, key):
-        assert is_jira_key(key)
+        if not is_jira_key(key):
+            raise ValueError(f"{key} is not a \
+                valid JIRA key")
         return key


### PR DESCRIPTION
'assert' can be ignored by the python interpreter if it is invoked with -O.

This changes the behavior in the Issue class' validator methods to make sure the values are always validated.