### PR TITLE
Fix unit test errors due to new version of pydantic

### DIFF
--- a/src/bugjira/config.py
+++ b/src/bugjira/config.py
@@ -1,30 +1,28 @@
 import json
 
-from pydantic import BaseModel, validator, constr
+import pydantic
+from pydantic import BaseModel, field_validator, constr
 
 
 class BugzillaConfig(BaseModel):
+    model_config = pydantic.ConfigDict(extra='forbid')
+
     URL: constr(strip_whitespace=True, min_length=1)
     api_key: constr(strip_whitespace=True, min_length=1)
 
-    class Config:
-        extra = 'forbid'
-
 
 class JiraConfig(BaseModel):
+    model_config = pydantic.ConfigDict(extra='forbid')
+
     URL: constr(strip_whitespace=True, min_length=1)
     token_auth: constr(strip_whitespace=True, min_length=1)
 
-    class Config:
-        extra = 'forbid'
-
 
 class ConfigDict(BaseModel):
+    model_config = pydantic.ConfigDict(extra='forbid')
+
     bugzilla: BugzillaConfig
     jira: JiraConfig
-
-    class Config:
-        extra = 'forbid'
 
 
 class Config(BaseModel):
@@ -32,7 +30,7 @@ class Config(BaseModel):
 
     config_dict: dict
 
-    @validator("config_dict")
+    @field_validator("config_dict")
     def validate_minimum_config(cls, v):
         ConfigDict(**v)
         return v

--- a/src/bugjira/issue.py
+++ b/src/bugjira/issue.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 from bugjira.util import is_bugzilla_key, is_jira_key
 
@@ -12,12 +12,12 @@ class Issue(BaseModel):
     """
 
     key: str
-    bugzilla: Any
-    jira_issue: Any
+    bugzilla: Any = None
+    jira_issue: Any = None
 
 
 class BugzillaIssue(Issue):
-    @validator("key")
+    @field_validator("key")
     def validate_key(cls, key):
         if not is_bugzilla_key(key):
             raise ValueError(f"{key} is not a \
@@ -26,7 +26,7 @@ class BugzillaIssue(Issue):
 
 
 class JiraIssue(Issue):
-    @validator("key")
+    @field_validator("key")
     def validate_key(cls, key):
         if not is_jira_key(key):
             raise ValueError(f"{key} is not a \

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -43,8 +43,8 @@ def test_config_extra_top_level_value(good_config_dict):
     assert len(excinfo.value.errors()) == 1
     error = excinfo.value.errors()[0]
     assert error.get("loc") == ("config_dict", "foo")
-    assert error.get("msg") == "extra fields not permitted"
-    assert error.get("type") == "value_error.extra"
+    assert error.get("msg") == "Extra inputs are not permitted"
+    assert error.get("type") == "extra_forbidden"
 
 
 def test_config_extra_bugzilla_value(good_config_dict):
@@ -62,8 +62,8 @@ def test_config_extra_bugzilla_value(good_config_dict):
     assert len(excinfo.value.errors()) == 1
     error = excinfo.value.errors()[0]
     assert error.get("loc") == ("config_dict", "bugzilla", "foo")
-    assert error.get("msg") == "extra fields not permitted"
-    assert error.get("type") == "value_error.extra"
+    assert error.get("msg") == "Extra inputs are not permitted"
+    assert error.get("type") == "extra_forbidden"
 
 
 def test_config_extra_jira_value(good_config_dict):
@@ -81,8 +81,8 @@ def test_config_extra_jira_value(good_config_dict):
     assert len(excinfo.value.errors()) == 1
     error = excinfo.value.errors()[0]
     assert error.get("loc") == ("config_dict", "jira", "foo")
-    assert error.get("msg") == "extra fields not permitted"
-    assert error.get("type") == "value_error.extra"
+    assert error.get("msg") == "Extra inputs are not permitted"
+    assert error.get("type") == "extra_forbidden"
 
 
 def test_config_missing_value(good_config_dict):
@@ -99,8 +99,8 @@ def test_config_missing_value(good_config_dict):
     assert len(excinfo.value.errors()) == 1
     error = excinfo.value.errors()[0]
     assert error.get("loc") == ("config_dict", "jira", "token_auth")
-    assert error.get("msg") == "field required"
-    assert error.get("type") == "value_error.missing"
+    assert error.get("msg") == "Field required"
+    assert error.get("type") == "missing"
 
 
 def test_config_empty_value(good_config_dict):
@@ -116,7 +116,7 @@ def test_config_empty_value(good_config_dict):
 
     assert len(excinfo.value.errors()) == 1
     error = excinfo.value.errors()[0]
-    assert error.get("ctx").get("limit_value") == 1
+    assert error.get("ctx").get("min_length") == 1
     assert error.get("loc") == ("config_dict", "jira", "token_auth")
 
 
@@ -132,8 +132,8 @@ def test_config_empty_values(config_defaults):
             config_path=(config_defaults + "/data/config/missing_config.json")
         )
     for error in excinfo.value.errors():
-        assert error.get("type") == "value_error.any_str.min_length"
-        assert error.get("ctx").get("limit_value") == 1
+        assert error.get("type") == "string_too_short"
+        assert error.get("ctx").get("min_length") == 1
 
 
 def test_config_no_file(config_defaults):


### PR DESCRIPTION
Pydantic updated to v2.x, so a bunch of pipeline unit tests started failing. This patch follows the migration recommendations from pydantic to get the tests passing again.