### PR TITLE
Rename ConfigDict class to avoid name clash with pydantic

### DIFF
--- a/src/bugjira/config.py
+++ b/src/bugjira/config.py
@@ -1,25 +1,24 @@
 import json
 
-import pydantic
-from pydantic import BaseModel, field_validator, constr
+from pydantic import ConfigDict, BaseModel, field_validator, constr
 
 
 class BugzillaConfig(BaseModel):
-    model_config = pydantic.ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra='forbid')
 
     URL: constr(strip_whitespace=True, min_length=1)
     api_key: constr(strip_whitespace=True, min_length=1)
 
 
 class JiraConfig(BaseModel):
-    model_config = pydantic.ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra='forbid')
 
     URL: constr(strip_whitespace=True, min_length=1)
     token_auth: constr(strip_whitespace=True, min_length=1)
 
 
-class ConfigDict(BaseModel):
-    model_config = pydantic.ConfigDict(extra='forbid')
+class BugjiraConfigDict(BaseModel):
+    model_config = ConfigDict(extra='forbid')
 
     bugzilla: BugzillaConfig
     jira: JiraConfig
@@ -32,7 +31,7 @@ class Config(BaseModel):
 
     @field_validator("config_dict")
     def validate_minimum_config(cls, v):
-        ConfigDict(**v)
+        BugjiraConfigDict(**v)
         return v
 
     @staticmethod

--- a/tests/unit/test_broker.py
+++ b/tests/unit/test_broker.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, create_autospec
 import pytest
 from bugzilla import Bugzilla
 from jira import JIRA
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 import bugjira.broker as broker
 from bugjira.broker import (

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 from bugjira.config import Config
 

--- a/tests/unit/test_issue.py
+++ b/tests/unit/test_issue.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic.error_wrappers import ValidationError
+from pydantic import ValidationError
 
 from bugjira.issue import BugzillaIssue, JiraIssue
 


### PR DESCRIPTION
The workaround in the previous patch left some technical debt in the form of ambiguity in the class names. This patch corrects that by renaming our class BugjiraConfigDict.

This patch also cleans up a pytest warning about how the pydantic ValidationError was moved to a different namespace in that library by adjusting the import statements we use.
