### PR TITLE
Adjust tox text matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+          python: ['3.10', '3.11']
       steps:
         - uses: actions/checkout@v3
         - name: Setup Python

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311}
+    py{310,311}
     flake8
 
 [testenv]


### PR DESCRIPTION
The test runs for python 3.7 and 3.8 started failing due to some type hinting in the bugjira source, and since we don't intend to support those pythons we can disable these older test environments.